### PR TITLE
Fix to match return of get_image_type to imghdr.what

### DIFF
--- a/lib/mobi_cover.py
+++ b/lib/mobi_cover.py
@@ -4,6 +4,8 @@
 
 from __future__ import unicode_literals, division, absolute_import, print_function
 
+from .compatibility_utils import PY2
+
 from .unipath import pathof
 import os
 import imghdr
@@ -48,7 +50,10 @@ def get_image_type(imgname, imgdata=None):
                 last-=1
             # Be extra safe, check the trailing bytes, too.
             if imgdata[last-2:last] == b'\xFF\xD9':
-                imgtype = "jpeg"
+                if PY2:
+                    imgtype = b"jpeg"
+                else:
+                    imgtype = "jpeg"
     return imgtype
 
 


### PR DESCRIPTION
Hi Kevin,

I have modified to the type of return value from unicode to byte string in python 2.

Please merge my fork of the KindleUnpack.

Take care,
tkeo