### PR TITLE
Fix mimetype umask

### DIFF
--- a/lib/unpack_structure.py
+++ b/lib/unpack_structure.py
@@ -160,6 +160,7 @@ xmlns:enc="http://www.w3.org/2001/04/xmlenc#" xmlns:deenc="http://ns.adobe.com/d
         with open(pathof(fileout),'wb') as f:
             f.write(mimetype)
         nzinfo = ZipInfo('mimetype', compress_type=zipfile.ZIP_STORED)
+        nzinfo.external_attr = 0o600 << 16L # make this a normal file
         self.outzip.writestr(nzinfo, mimetype)
         self.zipUpDir(self.outzip,self.k8dir,'META-INF')
         self.zipUpDir(self.outzip,self.k8dir,'OEBPS')


### PR DESCRIPTION
I found an ebook reader that didn't like the total lack of file permissions set for the embedded 'mimetype' file generated during the epub packaging process. This one-line change sets the permissions in the zip file to be the same as `rw-r--r--` on a normal UNIX system.