### PR TITLE
Allow relative import of imghdr

### DIFF
--- a/lib/mobi_cover.py
+++ b/lib/mobi_cover.py
@@ -8,7 +8,7 @@ from .compatibility_utils import unicode_str
 
 from .unipath import pathof
 import os
-import imghdr
+from . import imghdr
 
 import struct
 # note:  struct pack, unpack, unpack_from all require bytestring format


### PR DESCRIPTION
This is what works for me with Python 3.13+ (I would think it would work with pre-3.13 pythons as well). In either this standalone version of KindleUnpack, or in the plugins where I utilize the 'lib' folder. If possible, it would be best if imghdr.py stayed in this lib folder. I grap everything from that folder to build the Sigil/calibre plugins.

No need to merge this if you have other ideas. I'm just getting it out there.