### PR TITLE
fix: reading mobi dict with unencodable UTF-8 characters

### DIFF
--- a/lib/mobi_dict.py
+++ b/lib/mobi_dict.py
@@ -203,7 +203,7 @@ class dictSupport(object):
                             else:
                                 utext += unichr(off)
                             pos += inc
-                        text = utext.encode('utf-8')
+                        text = utext.encode('utf-8', 'replace')
 
                     tagMap = getTagMap(controlByteCount, tagTable, data, startPos+1+textLength, endPos)
                     if 0x01 in tagMap:


### PR DESCRIPTION
While trying to read a mobi dict (namely https://github.com/BoboTiG/ebook-reader-dict/releases/download/fro/dict-fro-fro.mobi.zip), I encountered this error:

```python
Parsing metaOrthIndex
orthIndexCount is 11
orth entry uses ordt2 lookup table of type  0
Read dictionary index data
Error: 'utf-8' codec can't encode characters in position 0-1: surrogates not allowed
Traceback (most recent call last):
  File "KindleUnpack.pyw", line 370, in unpackEbook
    kindleunpack.unpackBook(infile, outdir, apnxfile, epubversion, use_hd, dodump=dump, dowriteraw=writeraw, dosplitcombos=splitcombos)
  File "lib/kindleunpack.py", line 947, in unpackBook
    process_all_mobi_headers(files, apnxfile, sect, mhlst, K8Boundary, False, epubver, use_hd)
  File "lib/kindleunpack.py", line 868, in process_all_mobi_headers
    processMobi7(mh, metadata, sect, files, rscnames)
  File "lib/kindleunpack.py", line 645, in processMobi7
    positionMap = dictSupport(mh, sect).getPositionMap()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "lib/mobi_dict.py", line 206, in getPositionMap
    text = utext.encode('utf-8')
           ^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 0-1: surrogates not allowed

Error: Unpacking Failed
```

In fact, the dict contains all kind of unicode ranges, and this simple fix worked.

And thanks for the tool! :clinking_glasses: 